### PR TITLE
Fix accessing NonNullablePropertyHelper from multiple threads

### DIFF
--- a/MiniValidationPlus.sln.DotSettings
+++ b/MiniValidationPlus.sln.DotSettings
@@ -4,6 +4,8 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">135</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=4a98fdf6_002D7d98_002D4f5a_002Dafeb_002Dea44ad98c70c/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Instance" AccessRightKinds="Private" Description="Instance fields (private)"&gt;&lt;ElementKinds&gt;&lt;Kind Name="FIELD" /&gt;&lt;Kind Name="READONLY_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/MiniValidation/NonNullablePropertyHelper.cs
+++ b/src/MiniValidation/NonNullablePropertyHelper.cs
@@ -7,23 +7,23 @@ namespace MiniValidation
     /// <summary>
     /// Helper for non-nullable reference types.
     /// </summary>
-    public static class NonNullablePropertyHelper
+    public class NonNullablePropertyHelper
     {
-        private static readonly NullabilityInfoContext NullabilityContext = new ();
+        private readonly NullabilityInfoContext nullabilityContext = new ();
 
         /// <summary>
         /// Gets information whether the <paramref name="propertyInfo"/> is non-nullable reference type.
         /// </summary>
         /// <param name="propertyInfo">The property.</param>
         /// <returns><c>True</c> when <paramref name="propertyInfo"/> is non-nullable reference type, <c>False</c> otherwise.</returns>
-        public static bool IsNonNullableReferenceType(PropertyInfo propertyInfo)
+        public bool IsNonNullableReferenceType(PropertyInfo propertyInfo)
         {
             if (propertyInfo.PropertyType.IsValueType)
             {
                 return false;
             }
 
-            var nullabilityInfo = NullabilityContext.Create(propertyInfo);
+            var nullabilityInfo = nullabilityContext.Create(propertyInfo);
             return nullabilityInfo.WriteState is not NullabilityState.Nullable;
         }
     }

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -15,7 +15,10 @@ internal class TypeDetailsCache
 {
     private static readonly PropertyDetails[] _emptyPropertyDetails = Array.Empty<PropertyDetails>();
     private readonly ConcurrentDictionary<Type, (PropertyDetails[] Properties, bool RequiresAsync)> _cache = new();
-
+#if NET6_0_OR_GREATER
+    private NonNullablePropertyHelper _nonNullablePropertyHelper = new();
+#endif
+    
     public (PropertyDetails[] Properties, bool RequiresAsync) Get(Type? type)
     {
         if (type is null)
@@ -91,7 +94,7 @@ internal class TypeDetailsCache
             validationAttributes ??= Array.Empty<ValidationAttribute>();
 
 #if NET6_0_OR_GREATER
-            var isNonNullableReferenceType = NonNullablePropertyHelper.IsNonNullableReferenceType(property);
+            var isNonNullableReferenceType = _nonNullablePropertyHelper.IsNonNullableReferenceType(property);
 #else
             var isNonNullableReferenceType = false;
 #endif

--- a/tests/MiniValidation.UnitTests/NonNullablePropertyHelperTests.cs
+++ b/tests/MiniValidation.UnitTests/NonNullablePropertyHelperTests.cs
@@ -18,7 +18,7 @@ public class NonNullablePropertyHelperTests
                                                     | BindingFlags.Public
                                                     | BindingFlags.FlattenHierarchy))
         {
-            var isNonNullableReferenceType = NonNullablePropertyHelper.IsNonNullableReferenceType(property);
+            var isNonNullableReferenceType = new NonNullablePropertyHelper().IsNonNullableReferenceType(property);
             if (isNonNullableReferenceType)
             {
                 nonNullableReferenceTypes.Add(property.Name);
@@ -50,7 +50,7 @@ public class NonNullablePropertyHelperTests
                                                     | BindingFlags.Public
                                                     | BindingFlags.FlattenHierarchy))
         {
-            var isNonNullableReferenceType = NonNullablePropertyHelper.IsNonNullableReferenceType(property);
+            var isNonNullableReferenceType = new NonNullablePropertyHelper().IsNonNullableReferenceType(property);
             if (isNonNullableReferenceType)
             {
                 nonNullableReferenceTypes.Add(property.Name);


### PR DESCRIPTION
`NullabilityInfoContext` is not thread-safe (see i.e. https://github.com/dotnet/runtime/issues/100254). So `NonNullablePropertyHelper` was changed from static to instance class. For performance reasons instance is not created for every call to method `IsNonNullableReferenceType(property)` but it is created once in `TypeDetailsCache` class.

Previous solution with static class sometimes caused tests to fail because they run in parallel (see https://github.com/luboshl/MiniValidationPlus/actions/runs/9961358339/job/27522843648#step:7:42). The same could happen in application code.

```
Error Message:
   System.ArgumentException : An item with the same key has already been added. Key: MiniValidationPlus.UnitTests.TestChildType
  Stack Trace:
     at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Reflection.NullabilityInfoContext.GetNullableContext(MemberInfo memberInfo)
   at System.Reflection.NullabilityInfoContext.GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, Int32& index)
   at System.Reflection.NullabilityInfoContext.Create(PropertyInfo propertyInfo)
   at MiniValidationPlus.NonNullablePropertyHelper.IsNonNullableReferenceType(PropertyInfo propertyInfo) in /_/src/MiniValidationPlus/NonNullablePropertyHelper.cs:line 26
   at MiniValidationPlus.TypeDetailsCache.Visit(Type type, HashSet`1 visited, Boolean& requiresAsync) in /_/src/MiniValidationPlus/TypeDetailsCache.cs:line 90
   at MiniValidationPlus.TypeDetailsCache.Visit(Type type, HashSet`1 visited, Boolean& requiresAsync) in /_/src/MiniValidationPlus/TypeDetailsCache.cs:line 126
   at MiniValidationPlus.TypeDetailsCache.Visit(Type type) in /_/src/MiniValidationPlus/TypeDetailsCache.cs:line 38
   at MiniValidationPlus.TypeDetailsCache.Get(Type type) in /_/src/MiniValidationPlus/TypeDetailsCache.cs:line 28
   at MiniValidationPlus.MiniValidator.RequiresValidation(Type targetType, Boolean recurse) in /_/src/MiniValidationPlus/MiniValidator.cs:line [44](https://github.com/luboshl/MiniValidationPlus/actions/runs/9961358339/job/27522843648#step:7:45)
   at MiniValidationPlus.MiniValidator.TryValidateImpl[TTarget](TTarget target, IServiceProvider serviceProvider, Boolean recurse, Boolean allowAsync, IDictionary`2& errors) in /_/src/MiniValidationPlus/MiniValidator.cs:line 167
   at MiniValidationPlus.MiniValidator.TryValidate[TTarget](TTarget target, IDictionary`2& errors) in /_/src/MiniValidationPlus/MiniValidator.cs:line 60
   at MiniValidationPlus.UnitTests.TryValidate.NonRequiredValidator_Invalid_When_Invalid() in /_/tests/MiniValidationPlus.UnitTests/TryValidate.cs:line 58
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```