### PR TITLE
Attribute to allow to skip validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,48 @@ class WidgetWithCustomValidation : Widget, IValidatableObject
     }
 }
 ```
+
+## Skip validation
+
+You can set property to be skipped when validation is performed by setting `SkipValidationAttribute`
+on it. If you want to perform validation on the property, but not to validate it recursively
+(validate properties of the property), you can set `SkipRecursionAttribute` on it.
+
+When you use `SkipValidationAttribute` on a property, recursion is also skipped for that property.
+
+### Examples
+
+```csharp
+class Model
+{
+    [SkipValidation]
+    public string Name => throw new InvalidOperationException();
+
+    public ValidChild ValidChild { get; set; }
+
+    public ValidChildWithInvalidSkippedProperty ValidChildWithInvalidSkippedProperty { get; set; }
+
+    [SkipRecursion]
+    public InvalidChild InvalidChild { get; set; }
+}
+
+class ValidChild
+{
+    [Range(10, 100)]
+    public int TenOrMore { get; set; } = 10;
+}
+
+class ValidChildWithInvalidSkippedProperty
+{
+    // Property is invalid but is skipped
+    [SkipValidation]
+    public string Name { get; set; } = null!;
+}
+
+class InvalidChild
+{
+    // Property is invalid
+    [Range(10, 100)]
+    public int TenOrMore { get; set; } = 3;
+}
+```

--- a/src/MiniValidationPlus/SkipValidationAttribute.cs
+++ b/src/MiniValidationPlus/SkipValidationAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace MiniValidationPlus;
+
+/// <summary>
+/// Indicates that a property should be ignored during validation when using
+/// <see cref="MiniValidatorPlus.TryValidate{TTarget}(TTarget, out System.Collections.Generic.IDictionary{string, string[]})"/>.
+/// Note that also recursive validation will be ignored on the property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+public class SkipValidationAttribute : Attribute
+{
+}

--- a/tests/MiniValidationPlus.UnitTests/Recursion.cs
+++ b/tests/MiniValidationPlus.UnitTests/Recursion.cs
@@ -56,7 +56,7 @@ public class Recursion
     [Fact]
     public void Valid_When_Child_Invalid_And_Property_Decorated_With_SkipRecursion()
     {
-        var thingToValidate = new TestType { SkippedChild = new TestChildType { RequiredCategory = null, MinLengthFive = "123" } };
+        var thingToValidate = new TestType { SkippedRecursionChild = new TestChildType { RequiredCategory = null, MinLengthFive = "123" } };
 
         var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: false, out var errors);
 
@@ -99,7 +99,7 @@ public class Recursion
     [Fact]
     public void Valid_When_Enumerable_Item_Has_Invalid_Descendant_But_Property_Decorated_With_SkipRecursion()
     {
-        var thingToValidate = new List<TestType> { new() { SkippedChild = new() { RequiredCategory = null } } };
+        var thingToValidate = new List<TestType> { new() { SkippedRecursionChild = new() { RequiredCategory = null } } };
 
         var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: true, out _);
 
@@ -212,7 +212,7 @@ public class Recursion
     {
         var thingToValidate = new TestType();
         thingToValidate.Children.Add(new());
-        thingToValidate.Children.Add(new() { SkippedChild = new() { RequiredCategory = null } });
+        thingToValidate.Children.Add(new() { SkippedRecursionChild = new() { RequiredCategory = null } });
 
         var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: false, out var errors);
 

--- a/tests/MiniValidationPlus.UnitTests/Recursion.cs
+++ b/tests/MiniValidationPlus.UnitTests/Recursion.cs
@@ -90,7 +90,7 @@ public class Recursion
     public void Valid_When_Enumerable_Item_Invalid_When_Recurse_False()
     {
         var thingToValidate = new List<TestType> { new() { Child = new TestChildType { RequiredCategory = null, MinLengthFive = "123" } } };
-        
+
         var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: false, out _);
 
         Assert.True(result);
@@ -467,28 +467,6 @@ public class Recursion
         Assert.Single(errors);
         Assert.Equal($"{nameof(TestValidatableType.PocoChild)}.{nameof(TestAsyncValidatableChildType.TwentyOrMore)}", errors.Keys.First());
     }
-
-    [Fact]
-    public void Valid_When_String_Property_Invalid_And_Decorated_With_SkipValidation()
-    {
-        var thingToValidate = new TestType { SkippedValidationNonNullableString = null!};
-
-        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
-
-        Assert.True(result);
-        Assert.Empty(errors);
-    }
-    
-    [Fact]
-    public void Valid_When_Required_Property_Invalid_And_Decorated_With_SkipValidation()
-    {
-        var thingToValidate = new TestType { SkippedValidationRequiredName = null!};
-
-        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
-
-        Assert.True(result);
-        Assert.Empty(errors);
-    }
     
     [Fact]
     public void Valid_When_Child_Invalid_And_Decorated_With_SkipValidation()
@@ -500,7 +478,7 @@ public class Recursion
         Assert.True(result);
         Assert.Empty(errors);
     }
-    
+
     [Fact]
     public void Valid_When_Child_Has_Invalid_String_Property_Decorated_With_SkipValidation()
     {
@@ -511,7 +489,7 @@ public class Recursion
         Assert.True(result);
         Assert.Empty(errors);
     }
-    
+
     [Fact]
     public void Valid_When_Child_Has_Invalid_Required_Property_Decorated_With_SkipValidation()
     {

--- a/tests/MiniValidationPlus.UnitTests/Recursion.cs
+++ b/tests/MiniValidationPlus.UnitTests/Recursion.cs
@@ -467,4 +467,59 @@ public class Recursion
         Assert.Single(errors);
         Assert.Equal($"{nameof(TestValidatableType.PocoChild)}.{nameof(TestAsyncValidatableChildType.TwentyOrMore)}", errors.Keys.First());
     }
+
+    [Fact]
+    public void Valid_When_String_Property_Invalid_And_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { SkippedValidationNonNullableString = null!};
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
+    public void Valid_When_Required_Property_Invalid_And_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { SkippedValidationRequiredName = null!};
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
+    public void Valid_When_Child_Invalid_And_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { SkippedValidationChild = new TestChildType { RequiredCategory = null, MinLengthFive = "123" } };
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: true, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
+    public void Valid_When_Child_Has_Invalid_String_Property_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { Child = new TestChildType { SkippedValidationNonNullableString = null! } };
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: true, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
+    public void Valid_When_Child_Has_Invalid_Required_Property_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { Child = new TestChildType { SkippedValidationRequiredName = null! } };
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, recurse: true, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
 }

--- a/tests/MiniValidationPlus.UnitTests/TestTypes.cs
+++ b/tests/MiniValidationPlus.UnitTests/TestTypes.cs
@@ -40,6 +40,9 @@ class TestType
     public TestChildType SkippedValidationChild { get; set; } = new TestChildType();
 
     public IList<TestChildType> Children { get; } = new List<TestChildType>();
+
+    [SkipValidation]
+    public string SkippedPropertyThrowingException => throw new InvalidOperationException();
 }
 
 class TestValidatableType : TestType, IValidatableObject

--- a/tests/MiniValidationPlus.UnitTests/TestTypes.cs
+++ b/tests/MiniValidationPlus.UnitTests/TestTypes.cs
@@ -27,7 +27,7 @@ class TestType
     public IAnInterface? InterfaceProperty { get; set; }
 
     [SkipRecursion]
-    public TestChildType SkippedChild { get; set; } = new TestChildType();
+    public TestChildType SkippedRecursionChild { get; set; } = new TestChildType();
 
     public IList<TestChildType> Children { get; } = new List<TestChildType>();
 }
@@ -143,7 +143,7 @@ class TestChildType
     public TestChildType? Child { get; set; }
 
     [SkipRecursion]
-    public virtual TestChildType? SkippedChild { get; set; }
+    public virtual TestChildType? SkippedRecursionChild { get; set; }
 
     internal static void AddDescendents(TestChildType target, int maxDepth, int currentDepth = 1)
     {
@@ -215,7 +215,7 @@ class TestSkippedChildType
 {
     [Required]
     [SkipRecursion]
-    public TestChildType? RequiredSkippedChild { get; set; }
+    public TestChildType? RequiredSkippedRecursionChild { get; set; }
 }
 
 struct TestStruct

--- a/tests/MiniValidationPlus.UnitTests/TestTypes.cs
+++ b/tests/MiniValidationPlus.UnitTests/TestTypes.cs
@@ -6,8 +6,15 @@ class TestType
 {
     public string NonNullableString { get; set; } = "Default";
 
+    [SkipValidation]
+    public string SkippedValidationNonNullableString { get; set; } = "Default";
+
     [Required]
     public string? RequiredName { get; set; } = "Default";
+
+    [Required]
+    [SkipValidation]
+    public string? SkippedValidationRequiredName { get; set; } = "Default";
 
     [Required, Display(Name = "Required name")]
     public string? RequiredNameWithDisplay { get; set; } = "Default";
@@ -28,6 +35,9 @@ class TestType
 
     [SkipRecursion]
     public TestChildType SkippedRecursionChild { get; set; } = new TestChildType();
+
+    [SkipValidation]
+    public TestChildType SkippedValidationChild { get; set; } = new TestChildType();
 
     public IList<TestChildType> Children { get; } = new List<TestChildType>();
 }
@@ -141,6 +151,13 @@ class TestChildType
     public string? MinLengthFive { get; set; } = "Default";
 
     public TestChildType? Child { get; set; }
+
+    [SkipValidation]
+    public string SkippedValidationNonNullableString { get; set; } = "Default";
+
+    [Required]
+    [SkipValidation]
+    public string? SkippedValidationRequiredName { get; set; } = "Default";
 
     [SkipRecursion]
     public virtual TestChildType? SkippedRecursionChild { get; set; }

--- a/tests/MiniValidationPlus.UnitTests/TryValidate.cs
+++ b/tests/MiniValidationPlus.UnitTests/TryValidate.cs
@@ -553,4 +553,18 @@ public class TryValidate
         Assert.True(result);
         Assert.Empty(errors);
     }
+    
+    [Fact]
+    public void Valid_When_Property_With_Setter_Throwing_Exception_And_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType();
+        var setter = () => thingToValidate.SkippedPropertyThrowingException;
+
+        var exception = Record.Exception(setter);
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.NotNull(exception);
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
 }

--- a/tests/MiniValidationPlus.UnitTests/TryValidate.cs
+++ b/tests/MiniValidationPlus.UnitTests/TryValidate.cs
@@ -531,4 +531,26 @@ public class TryValidate
         Assert.Single(errors["PropertyToBeRequired"]);
         Assert.Single(errors["AnotherProperty"]);
     }
+
+    [Fact]
+    public void Valid_When_String_Property_Invalid_And_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { SkippedValidationNonNullableString = null!};
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
+    public void Valid_When_Required_Property_Invalid_And_Decorated_With_SkipValidation()
+    {
+        var thingToValidate = new TestType { SkippedValidationRequiredName = null!};
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
 }


### PR DESCRIPTION
`SkipValidationAttribute` was added to allow to set property to be skipped when validation is performed.