### PR TITLE
Opt-out validation of non-nullable reference types

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,12 @@ class InvalidChild
     public int TenOrMore { get; set; } = 3;
 }
 ```
+
+## Opt-out validation of non-nullable reference types
+
+You can disable validation of properties that are non-nullable reference types by configuring `ValidationSettings`:
+
+```csharp
+var validationSettings = ValidationSettings.Default with { ValidateNonNullableReferenceTypes = false };
+var isValid = MiniValidatorPlus.TryValidate(objectToValidate, validationSettings, out var errors);
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,58 @@ class Widget
 }
 ```
 
+### Skip validation
+
+You can set property to be skipped when validation is performed by setting `SkipValidationAttribute`
+on it. If you want to perform validation on the property, but not to validate it recursively
+(validate properties of the property), you can set `SkipRecursionAttribute` on it.
+
+When you use `SkipValidationAttribute` on a property, recursion is also skipped for that property.
+
+```csharp
+class Model
+{
+    [SkipValidation]
+    public string Name => throw new InvalidOperationException();
+
+    public ValidChild ValidChild { get; set; }
+
+    public ValidChildWithInvalidSkippedProperty ValidChildWithInvalidSkippedProperty { get; set; }
+
+    [SkipRecursion]
+    public InvalidChild InvalidChild { get; set; }
+}
+
+class ValidChild
+{
+    [Range(10, 100)]
+    public int TenOrMore { get; set; } = 10;
+}
+
+class ValidChildWithInvalidSkippedProperty
+{
+    // Property is invalid but is skipped
+    [SkipValidation]
+    public string Name { get; set; } = null!;
+}
+
+class InvalidChild
+{
+    // Property is invalid
+    [Range(10, 100)]
+    public int TenOrMore { get; set; } = 3;
+}
+```
+
+### Opt-out validation of non-nullable reference types
+
+You can disable validation of properties that are non-nullable reference types by configuring `ValidationSettings`:
+
+```csharp
+var validationSettings = ValidationSettings.Default with { ValidateNonNullableReferenceTypes = false };
+var isValid = MiniValidatorPlus.TryValidate(objectToValidate, validationSettings, out var errors);
+```
+
 ### Use services from validators
 
 ```csharp
@@ -216,58 +268,4 @@ class WidgetWithCustomValidation : Widget, IValidatableObject
         }
     }
 }
-```
-
-## Skip validation
-
-You can set property to be skipped when validation is performed by setting `SkipValidationAttribute`
-on it. If you want to perform validation on the property, but not to validate it recursively
-(validate properties of the property), you can set `SkipRecursionAttribute` on it.
-
-When you use `SkipValidationAttribute` on a property, recursion is also skipped for that property.
-
-### Examples
-
-```csharp
-class Model
-{
-    [SkipValidation]
-    public string Name => throw new InvalidOperationException();
-
-    public ValidChild ValidChild { get; set; }
-
-    public ValidChildWithInvalidSkippedProperty ValidChildWithInvalidSkippedProperty { get; set; }
-
-    [SkipRecursion]
-    public InvalidChild InvalidChild { get; set; }
-}
-
-class ValidChild
-{
-    [Range(10, 100)]
-    public int TenOrMore { get; set; } = 10;
-}
-
-class ValidChildWithInvalidSkippedProperty
-{
-    // Property is invalid but is skipped
-    [SkipValidation]
-    public string Name { get; set; } = null!;
-}
-
-class InvalidChild
-{
-    // Property is invalid
-    [Range(10, 100)]
-    public int TenOrMore { get; set; } = 3;
-}
-```
-
-## Opt-out validation of non-nullable reference types
-
-You can disable validation of properties that are non-nullable reference types by configuring `ValidationSettings`:
-
-```csharp
-var validationSettings = ValidationSettings.Default with { ValidateNonNullableReferenceTypes = false };
-var isValid = MiniValidatorPlus.TryValidate(objectToValidate, validationSettings, out var errors);
 ```

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidationPlus/ValidationSettings.cs
+++ b/src/MiniValidationPlus/ValidationSettings.cs
@@ -13,4 +13,14 @@ public record ValidationSettings(
     IServiceProvider? ServiceProvider = null,
     bool Recurse = true,
     bool AllowAsync = false,
-    bool ValidateNonNullableReferenceTypes = true);
+    bool ValidateNonNullableReferenceTypes = true)
+{
+    /// <summary>
+    /// Default settings.
+    /// </summary>
+    public static ValidationSettings Default { get; } = new(
+        ServiceProvider: null,
+        Recurse: true,
+        AllowAsync: false,
+        ValidateNonNullableReferenceTypes: true);
+}

--- a/src/MiniValidationPlus/ValidationSettings.cs
+++ b/src/MiniValidationPlus/ValidationSettings.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace MiniValidationPlus;
+
+/// <summary>
+/// Configuration parameters for validation.
+/// </summary>
+/// <param name="ServiceProvider">The service provider to use when creating ValidationContext.</param>
+/// <param name="Recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <c>target</c> are validated.</param>
+/// <param name="AllowAsync"><c>true</c> to allow asynchronous validation if an object in the graph requires it.</param>
+public record ValidationSettings(
+    IServiceProvider? ServiceProvider = null,
+    bool Recurse = true,
+    bool AllowAsync = false);

--- a/src/MiniValidationPlus/ValidationSettings.cs
+++ b/src/MiniValidationPlus/ValidationSettings.cs
@@ -8,7 +8,9 @@ namespace MiniValidationPlus;
 /// <param name="ServiceProvider">The service provider to use when creating ValidationContext.</param>
 /// <param name="Recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <c>target</c> are validated.</param>
 /// <param name="AllowAsync"><c>true</c> to allow asynchronous validation if an object in the graph requires it.</param>
+/// <param name="ValidateNonNullableReferenceTypes"><c>true</c> to validate properties of non-nullable reference types as required.</param>
 public record ValidationSettings(
     IServiceProvider? ServiceProvider = null,
     bool Recurse = true,
-    bool AllowAsync = false);
+    bool AllowAsync = false,
+    bool ValidateNonNullableReferenceTypes = true);


### PR DESCRIPTION
- Configuration parameters were extracted to separate `ValidationSetting`
- New overloads of methods `TryValidate` and `TryValidateAsync` where created
  - They accept `ValidationSetting` instead of separate parameters
- To disable validation of non-nullable reference types, `ValidationSetting.ValidateNonNullableReferenceTypes` must be set to `false`