### PR TITLE
Fix getting nullability info for property with getter only

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidationPlus/NonNullablePropertyHelper.cs
+++ b/src/MiniValidationPlus/NonNullablePropertyHelper.cs
@@ -24,7 +24,7 @@ namespace MiniValidationPlus
             }
 
             var nullabilityInfo = nullabilityContext.Create(propertyInfo);
-            return nullabilityInfo.WriteState is not NullabilityState.Nullable;
+            return nullabilityInfo.ReadState is not NullabilityState.Nullable;
         }
     }
 }

--- a/tests/MiniValidationPlus.UnitTests/NonNullablePropertyHelperTests.cs
+++ b/tests/MiniValidationPlus.UnitTests/NonNullablePropertyHelperTests.cs
@@ -36,6 +36,7 @@ public class NonNullablePropertyHelperTests
         Assert.Contains(nameof(ClassModel.IntNullable), other);
         Assert.Contains(nameof(ClassModel.StringNullable), other);
         Assert.Contains(nameof(ClassModel.AnotherNullable), other);
+        Assert.Contains(nameof(ClassModel.StringNullableWithoutSetter), other);
     }
 
     [Fact]
@@ -70,12 +71,14 @@ public class NonNullablePropertyHelperTests
         Assert.Contains(nameof(RecordModel.AnotherNullable), other);
     }
 
+    [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
     private class ClassModel
     {
         public int IntNonNullable { get; set; }
         public int? IntNullable { get; set; }
         public string StringNonNullable { get; set; } = null!;
         public string? StringNullable { get; set; }
+        public string? StringNullableWithoutSetter { get; }
         public AnotherModel AnotherNonNullable { get; set; } = new();
         public AnotherModel? AnotherNullable { get; set; }
     }

--- a/tests/MiniValidationPlus.UnitTests/TestTypes.cs
+++ b/tests/MiniValidationPlus.UnitTests/TestTypes.cs
@@ -285,3 +285,28 @@ class TestTypeForTypeDescriptor
     [MaxLength(1)]
     public string? AnotherProperty { get; set; } = "Test";
 }
+
+class TestTypeWithPropertiesWithoutSetter
+{
+    public string NonNullableString { get; }
+
+    public string? NullableString { get; }
+
+    [Required(AllowEmptyStrings = false)]
+    public string RequiredNonNullableString { get; }
+
+    [Required(AllowEmptyStrings = false)]
+    public string? RequiredNullableString { get; }
+
+    public TestTypeWithPropertiesWithoutSetter(
+        string nonNullableString = "Default",
+        string? nullableString = "Default",
+        string requiredNonNullableString = "Default", 
+        string? requiredNullableString = "Default")
+    {
+        NonNullableString = nonNullableString;
+        NullableString = nullableString;
+        RequiredNonNullableString = requiredNonNullableString;
+        RequiredNullableString = requiredNullableString;
+    }
+}

--- a/tests/MiniValidationPlus.UnitTests/TryValidate.cs
+++ b/tests/MiniValidationPlus.UnitTests/TryValidate.cs
@@ -162,6 +162,138 @@ public class TryValidate
         Assert.False(result);
         Assert.Single(errors);
     }
+
+    [Fact]
+    public void PropertyWithoutSetter_NonNullable_Valid_When_NonEmpty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(nonNullableString: "test");
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_NonNullable_Valid_When_Empty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(nonNullableString: string.Empty);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_NonNullable_Invalid_When_Null()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(nonNullableString: null!);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public void PropertyWithoutSetter_Nullable_Valid_When_NonEmpty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(nullableString: "test");
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_Nullable_Valid_When_Empty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(nullableString: string.Empty);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_Nullable_Valid_When_Null()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(nullableString: null!);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void PropertyWithoutSetter_RequiredNonNullable_Valid_When_NonEmpty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(requiredNonNullableString: "test");
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_RequiredNonNullable_Invalid_When_Empty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(requiredNonNullableString: string.Empty);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Single(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_RequiredNonNullable_Invalid_When_Null()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(requiredNonNullableString: null!);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public void PropertyWithoutSetter_RequiredNullable_Valid_When_NonEmpty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(requiredNullableString: "test");
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_RequiredNullable_Invalid_When_Empty()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(requiredNullableString: string.Empty);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Single(errors);
+    }   
+
+    [Fact]
+    public void PropertyWithoutSetter_RequiredNullable_Invalid_When_Null()
+    {
+        var thingToValidate = new TestTypeWithPropertiesWithoutSetter(requiredNullableString: null!);
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Single(errors);
+    }
 #endif
 
     [Fact]


### PR DESCRIPTION
`NonNullablePropertyHelper` uses `NullabilityInfoContext` to get info about nullability of the given property. There was used `WriteState` to get that info. But when property has no setter, `WriteState` is `null`.

The fix is to use `ReadState` instead `WriteState`, because property has to have getter when it should be validated.

I've created separate commit with failing tests to repro the bug: b6ba1c0e55743304448e6e3522a89c0afca2e445

Tests that fail:
- `NonNullablePropertyHelperTests.IsNonNullableReferenceType_Identifies_Correct_Properties_Of_Class`
- `TryValidate.PropertyWithoutSetter_Nullable_Valid_When_Null`

This PR solves #16 