### PR TITLE
Fix processing of ValidationResult.Success

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidationPlus/MiniValidatorPlus.cs
+++ b/src/MiniValidationPlus/MiniValidatorPlus.cs
@@ -700,7 +700,9 @@ public static class MiniValidatorPlus
 
     private static void ProcessValidationResults(IEnumerable<ValidationResult> validationResults, Dictionary<string, List<string>> errors, string? prefix)
     {
-        foreach (var result in validationResults)
+        var failedValidationResults = validationResults.Where(x => x != ValidationResult.Success);
+        
+        foreach (var result in failedValidationResults)
         {
             var hasMemberNames = false;
             foreach (var memberName in result.MemberNames)

--- a/tests/MiniValidationPlus.UnitTests/TestTypes.cs
+++ b/tests/MiniValidationPlus.UnitTests/TestTypes.cs
@@ -310,3 +310,11 @@ class TestTypeWithPropertiesWithoutSetter
         RequiredNullableString = requiredNullableString;
     }
 }
+
+class ValidatableObjectWithSuccessValidationResultTestType : IValidatableObject
+{
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        yield return ValidationResult.Success;
+    }
+}

--- a/tests/MiniValidationPlus.UnitTests/TryValidate.cs
+++ b/tests/MiniValidationPlus.UnitTests/TryValidate.cs
@@ -433,6 +433,17 @@ public class TryValidate
     }
 
     [Fact]
+    public void Valid_When_ValidatableObject_Has_Success_ValidationResult()
+    {
+        var thingToValidate = new ValidatableObjectWithSuccessValidationResultTestType();
+
+        var result = MiniValidatorPlus.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Empty(errors);
+    }
+    
+    [Fact]
     public void Invalid_When_ValidatableObject_Validate_Is_Invalid()
     {
         var thingToValidate = new TestValidatableType


### PR DESCRIPTION
As @tjasek225 reported in #17, `System.ComponentModel.DataAnnotations.ValidationResult.Success` is `null` by design.

This situation was not covered in the code of `MiniValidatorPlus`.

Failing test to repro the issue: https://github.com/luboshl/MiniValidationPlus/commit/747743e8c07c7d125ac79dbb72f5619a4e61b01f